### PR TITLE
load singularity, jobId format fix

### DIFF
--- a/job_manager/lib/commands/submit.pl
+++ b/job_manager/lib/commands/submit.pl
@@ -337,7 +337,7 @@ sub addJob { # act on the assembled job
 }
 sub padSubmitEchoColumns {  # ensure pretty parsing of echoed status table
     my(@in) = @_;
-    my @columnWidths = (40, 1, 7, 5, 20);
+    my @columnWidths = (40, 1, 9, 5, 20);
     foreach my $i(0..4){
         my $value = $in[$i];
         my $outWidth = $columnWidths[$i];    

--- a/pipeline/launcher/execute.pl
+++ b/pipeline/launcher/execute.pl
@@ -111,8 +111,8 @@ sub setRuntimeEnvVars {
         "valid values are 'direct', 'conda', 'container', 'singularity', or 'auto'"
     );  
     setEnvVariable('runtime', $runtime); 
+    $ENV{SINGULARITY_LOAD_COMMAND} = getSingularityLoadCommand();
     if($ENV{RUNTIME} eq 'auto'){
-        $ENV{SINGULARITY_LOAD_COMMAND} = getSingularityLoadCommand();
         if($ENV{SINGULARITY_LOAD_COMMAND}){
             if(suiteSupportsContainers() and getSuiteContainerStage('pipelines')){
                 $ENV{RUNTIME} = 'container'; # suite containers take precedence if pipelines installed in them
@@ -133,7 +133,7 @@ sub setRuntimeEnvVars {
             "pipeline '$pipelineName' does not support containers\n".
             "please set option --runtime to 'direct', 'conda', or 'auto'"
         );  
-        $ENV{SINGULARITY_LOAD_COMMAND} = getSingularityLoadCommand() or throwError(
+        $ENV{SINGULARITY_LOAD_COMMAND} or throwError(
             "could not find a way to load singularity from PATH or singularity.yml\n".
             "please set option --runtime to 'direct', 'conda', or 'auto', install singularity, or edit:\n".
             "    mdi/config/singularity.yml >> load-command"

--- a/pipeline/launcher/lib/execute.sh
+++ b/pipeline/launcher/lib/execute.sh
@@ -7,6 +7,14 @@ ${CONDA_LOAD_COMMAND}
 source ${CONDA_PROFILE_SCRIPT}
 conda activate ${ENVIRONMENTS_DIR}/${CONDA_NAME}
 
+# load singularity in the running job if instructed by the pipeline via env-vars
+# i.e., if the pipeline actions require running a singularity container
+if [[ "$LOAD_SINGULARITY" != "" && "$SINGULARITY_LOAD_COMMAND" != "" ]]; then
+    echo "loading singularity"
+    SINGULARITY_LOAD_COMMAND=`echo $SINGULARITY_LOAD_COMMAND | sed 's/>.*//'`
+    $SINGULARITY_LOAD_COMMAND
+fi
+
 # prepare the task workflow for execution
 source ${WORKFLOW_SH}
 if [ "${LAST_SUCCESSFUL_STEP}" != "" ]; then


### PR DESCRIPTION
Two changes:

- add pipeline action config `--load-singularity` to instruct the framework to load singularity for selected pipeline actions based on server configuration

- increase the number of characters used to display job IDs, for busy servers with lots of jobs